### PR TITLE
cmake: read buildspec.json instead of modifying cmakelists.txt

### DIFF
--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -172,36 +172,8 @@ Usage: %B${functrace[1]%:*}%b <option> [<options>]
   local product_author
   local product_email
 
-  IFS=/ read -r product_name product_version product_author product_email <<< \
-    "$(jq -r '. | {name, version, author, email} | join("/")' ${buildspec_file})"
-
-  product_author=\"${product_author}\"
-  product_email=\"${product_email}\"
-
-  case ${host_os} {
-    macos)
-      sed -i '' \
-        "s/project(\(.*\) VERSION \(.*\))/project(${product_name} VERSION ${product_version})/" \
-        "${project_root}/CMakeLists.txt"
-      sed -i '' \
-        "s/set(PLUGIN_AUTHOR \(.*\))/set(PLUGIN_AUTHOR ${product_author})/"\
-        "${project_root}/CMakeLists.txt"
-      sed -i '' \
-        "s/set(LINUX_MAINTAINER_EMAIL \(.*\))/set(LINUX_MAINTAINER_EMAIL ${product_email})/"\
-        "${project_root}/CMakeLists.txt"
-      ;;
-    linux)
-      sed -i'' \
-        "s/project(\(.*\) VERSION \(.*\))/project(${product_name} VERSION ${product_version})/"\
-        "${project_root}/CMakeLists.txt"
-      sed -i'' \
-        "s/set(PLUGIN_AUTHOR \(.*\))/set(PLUGIN_AUTHOR ${product_author})/"\
-        "${project_root}/CMakeLists.txt"
-      sed -i'' \
-        "s/set(LINUX_MAINTAINER_EMAIL \(.*\))/set(LINUX_MAINTAINER_EMAIL ${product_email})/"\
-        "${project_root}/CMakeLists.txt"
-      ;;
-  }
+  IFS=/ read -r product_name product_version <<< \
+    "$(jq -r '. | {name, version} | join("/")' ${buildspec_file})"
 
   setup_obs
 

--- a/.github/scripts/Build-Windows.ps1
+++ b/.github/scripts/Build-Windows.ps1
@@ -57,10 +57,6 @@ function Build {
         $CmakeGenerator = $script:VisualStudioVersion
     }
 
-    (Get-Content -Path ${ProjectRoot}/CMakeLists.txt -Raw) `
-        -replace "project\((.*) VERSION (.*)\)", "project(${ProductName} VERSION ${ProductVersion})" `
-        | Out-File -Path ${ProjectRoot}/CMakeLists.txt -NoNewline
-
     Setup-Obs
 
     Push-Location -Stack BuildTemp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ string(JSON BUILDSPEC_NAME GET ${BUILDSPEC_JSON} name)
 string(JSON BUILDSPEC_VERSION GET ${BUILDSPEC_JSON} version)
 string(JSON PLUGIN_AUTHOR GET ${BUILDSPEC_JSON} author)
 string(JSON LINUX_MAINTAINER_EMAIL GET ${BUILDSPEC_JSON} email)
-message("building ${BUILDSPEC_NAME}, ${BUILDSPEC_VERSION}, ${PLUGIN_AUTHOR} <${LINUX_MAINTAINER_EMAIL}>")
 
 # Change obs-plugintemplate to your plugin's name in a machine-readable format (e.g.:
 # obs-myawesomeplugin) and set

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,24 +2,20 @@ cmake_minimum_required(VERSION 3.19...3.21)
 
 # read details from the buildspec json file
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/buildspec.json BUILDSPEC_JSON)
+string(JSON BUILDSPEC_NAME GET ${BUILDSPEC_JSON} name)
 string(JSON BUILDSPEC_VERSION GET ${BUILDSPEC_JSON} version)
-message("building version ${BUILDSPEC_VERSION}")
+string(JSON PLUGIN_AUTHOR GET ${BUILDSPEC_JSON} author)
+string(JSON LINUX_MAINTAINER_EMAIL GET ${BUILDSPEC_JSON} email)
+message("building ${BUILDSPEC_NAME}, ${BUILDSPEC_VERSION}, ${PLUGIN_AUTHOR} <${LINUX_MAINTAINER_EMAIL}>")
 
 # Change obs-plugintemplate to your plugin's name in a machine-readable format (e.g.:
 # obs-myawesomeplugin) and set
-project(obs-plugintemplate VERSION ${BUILDSPEC_VERSION})
+project(${BUILDSPEC_NAME} VERSION ${BUILDSPEC_VERSION})
 add_library(${CMAKE_PROJECT_NAME} MODULE)
-
-# Replace `Your Name Here` with the name (yours or your organization's) you want to see as the
-# author of the plugin (in the plugin's metadata itself and in the installers)
-set(PLUGIN_AUTHOR "Your Name Here")
 
 # Replace `com.example.obs-plugin-template` with a unique Bundle ID for macOS releases (used both in
 # the installer and when submitting the installer for notarization)
 set(MACOS_BUNDLEID "com.example.${CMAKE_PROJECT_NAME}")
-
-# Replace `me@contoso.com` with the maintainer email address you want to put in Linux packages
-set(LINUX_MAINTAINER_EMAIL "me@mymailhost.com")
 
 # Add your custom source files here - header files are optional and only required for visibility
 # e.g. in Xcode or Visual Studio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,13 @@
-cmake_minimum_required(VERSION 3.16...3.21)
+cmake_minimum_required(VERSION 3.19...3.21)
+
+# read details from the buildspec json file
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/buildspec.json BUILDSPEC_JSON)
+string(JSON BUILDSPEC_VERSION GET ${BUILDSPEC_JSON} version)
+message("building version ${BUILDSPEC_VERSION}")
 
 # Change obs-plugintemplate to your plugin's name in a machine-readable format (e.g.:
 # obs-myawesomeplugin) and set
-project(obs-plugintemplate VERSION 1.0.0)
+project(obs-plugintemplate VERSION ${BUILDSPEC_VERSION})
 add_library(${CMAKE_PROJECT_NAME} MODULE)
 
 # Replace `Your Name Here` with the name (yours or your organization's) you want to see as the


### PR DESCRIPTION
Various data in buildspec.json is needed by cmake, including plugin name, version, author and email. The current build scripts inject that data over by rewriting CMakeLists.txt, but modifying version controlled causes problems when multiple build directories share the same source tree. Multiple builds will corrupt cmakelists if they try to rewrite at the same time, and it can trigger file changed signals when nothing has actually happened.

Instead use the cmake json feature to read buildspec.json right from within cmake. This eliminates the need to modify the file and it simplifies the build as a bonus.

note: this change requires cmake 3.19 or newer.

Signed-off-by: Grant Likely <grant.likely@secretlab.ca>